### PR TITLE
use go1.5 instead of go1.4

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/cloudfoundry-samples/logging-route-service",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Deps": [
 		{
 			"ImportPath": "github.com/elazarl/goproxy",


### PR DESCRIPTION
go1.4 has been deprecated recently in the go buildpack which is causing
CATS to fail. This app is one of the sample apps used in CATS.
