### PR TITLE
Fix the use of the $SKIP_SSL_VALIDATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ cf restage logging-route-service
 
 ### SKIP_SSL_VALIDATION
 
-If you set this environment variable to false, the route service
-will validate SSL certificates. By default the route service skips SSL validation.
+Set this environment variable to true in order to skip the validation of SSL certificates.
+By default the route service will attempt to validate certificates.
 
 Example:
 
 ```sh
-cf set-env logging-route-service SKIP_SSL_VALIDATION false
+cf set-env logging-route-service SKIP_SSL_VALIDATION true
 cf restart logging-route-service
 ```

--- a/main.go
+++ b/main.go
@@ -20,18 +20,12 @@ const (
 )
 
 func main() {
-	var (
-		port              string
-		skipSslValidation bool
-		err               error
-	)
-
-	if port = os.Getenv("PORT"); len(port) == 0 {
+	port := os.Getenv("PORT")
+	if len(port) == 0 {
 		port = DEFAULT_PORT
 	}
-	if skipSslValidation, err = strconv.ParseBool(os.Getenv("SKIP_SSL_VALIDATION")); err != nil {
-		skipSslValidation = true
-	}
+	skipSslValidation, _ := strconv.ParseBool(os.Getenv("SKIP_SSL_VALIDATION"))
+
 	log.SetOutput(os.Stdout)
 
 	roundTripper := NewLoggingRoundTripper(skipSslValidation)


### PR DESCRIPTION
- The current code was flawed in that it configured the application to skip SSL validation even if the environment variable was set to false.
- Update README to assume secure by default (ie don't skip validation)

Co-Authored-By: Patrick Huber <phuber@pivotal.io>