### PR TITLE
Add go.mod for Go 1.16 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudfoundry-samples/logging-route-service
+
+go 1.16


### PR DESCRIPTION
The app started failing with Go buildpack v1.9.27:
```
[2021-03-05 21:19:05.81 (UTC)]> cf push CATS-5-APP-aed3dd538baff830 --no-start -b go_buildpack -m 256M -p assets/logging-route-service -f assets/logging-route-service/manifest.yml 
Pushing app CATS-5-APP-aed3dd538baff830 to org CATS-5-ORG-148039e25025071c / space CATS-5-SPACE-6d2a49f9429bc058 as CATS-5-USER-3bf6107afed5ebf6...
Applying manifest file assets/logging-route-service/manifest.yml...
Manifest applied
Packaging files to upload...
Uploading files...
 6.28 KiB / 6.28 KiB [==================================================================================================================================================================================================================================================================================================================================================================================================================================================================================] 100.00% 1s

Waiting for API to complete processing files...

name:              CATS-5-APP-aed3dd538baff830
requested state:   stopped
routes:            CATS-5-APP-aed3dd538baff830.luna.cf-app.com
last uploaded:     
stack:             
buildpacks:        

type:           web
sidecars:       
instances:      0/1
memory usage:   256M
     state   since                  cpu    memory   disk     details
#0   down    2021-03-05T21:19:16Z   0.0%   0 of 0   0 of 0   

[2021-03-05 21:19:17.81 (UTC)]> cf start CATS-5-APP-aed3dd538baff830 
Starting app CATS-5-APP-aed3dd538baff830 in org CATS-5-ORG-148039e25025071c / space CATS-5-SPACE-6d2a49f9429bc058 as CATS-5-USER-3bf6107afed5ebf6...

Staging app and tracing logs...
   Downloading go_buildpack...
   Downloaded go_buildpack
   Cell 9ce4f955-3a1e-4eab-bf5e-31b1bf668288 creating container for instance 81012b0c-8dda-4708-82c1-db633a8e0ecc
   Cell 9ce4f955-3a1e-4eab-bf5e-31b1bf668288 successfully created container for instance 81012b0c-8dda-4708-82c1-db633a8e0ecc
   Downloading app package...
   Downloaded app package (6.3K)
   -----> Go Buildpack version 1.9.27
          **WARNING** [DEPRECATION WARNING]:
          **WARNING** Please use AppDynamics extension buildpack for Golang Application instrumentation
          **WARNING** for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html
   -----> Installing godep 80
          Download [https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz]
   -----> Installing glide 0.13.3
          Download [https://buildpacks.cloudfoundry.org/dependencies/glide/glide-v0.13.3-linux-x64-cflinuxfs3-ef07acb5.tgz]
   -----> Installing dep 0.5.4
          Download [https://buildpacks.cloudfoundry.org/dependencies/dep/dep-v0.5.4-linux-x64-cflinuxfs3-79b3ab9e.tgz]
   -----> Installing go 1.16
          Download [https://buildpacks.cloudfoundry.org/dependencies/go/go_1.16_linux_x64_cflinuxfs3_4ebb61dc.tgz]
Error staging application: BuildpackCompileFailed - App staging failed in the buildpack compile phase
FAILED
```