### PR TITLE
Bump Golang to 1.18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
-go 1.16
+go 1.18


### PR DESCRIPTION
This PR bumps Golang to 1.18 in the `go.mod` file. It also adds a dependabot config to generate future bump PRs automatically.